### PR TITLE
Add automatic loading of LangSmith API key from .env file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "langchain-openai",
     "pandas>=0.2.4",
     "rich",
+    "python-dotenv>=1.0.1",
 ]
 
 [project.scripts]

--- a/src/promptim/__main__.py
+++ b/src/promptim/__main__.py
@@ -104,6 +104,16 @@ async def run(
     return prompt, score
 
 
+def load_environment():
+    """Load environment variables from .env file if it exists in current directory."""
+    env_path = os.path.join(os.getcwd(), ".env")
+    if os.path.exists(env_path):
+        from dotenv import load_dotenv
+
+        load_dotenv(env_path)
+        click.echo(f"Loaded environment variables from {env_path}")
+
+
 @click.group()
 @click.version_option(version="1")
 def cli():
@@ -119,7 +129,8 @@ def cli():
     Example:
         promptim train --task ./my-task/config.json
     """
-    pass
+    # Load environment variables at the start of CLI execution
+    load_environment()
 
 
 @cli.command()
@@ -213,6 +224,7 @@ def _try_get_prompt(client: Client, prompt: str | None, yes: bool):
     from langchain_core.prompts import ChatPromptTemplate
     from langchain_core.prompts.structured import StructuredPrompt
     from langchain_core.runnables import RunnableBinding, RunnableSequence
+
     from promptim.trainer import PromptWrapper
 
     expected_run_outputs = 'predicted: AIMessage = run.outputs["output"]'
@@ -594,9 +606,9 @@ def create_task(
         },
         "initial_prompt": {"identifier": identifier},
     }
-    config[
-        "$schema"
-    ] = "https://raw.githubusercontent.com/hinthornw/promptimizer/refs/heads/main/config-schema.json"
+    config["$schema"] = (
+        "https://raw.githubusercontent.com/hinthornw/promptimizer/refs/heads/main/config-schema.json"
+    )
     with open(os.path.join(path, "config.json"), "w") as f:
         json.dump(config, f, indent=2)
 
@@ -785,9 +797,9 @@ def create_example_task(path: str, name: str):
         },
     }
 
-    config[
-        "$schema"
-    ] = "https://raw.githubusercontent.com/hinthornw/promptimizer/refs/heads/main/config-schema.json"
+    config["$schema"] = (
+        "https://raw.githubusercontent.com/hinthornw/promptimizer/refs/heads/main/config-schema.json"
+    )
     with open(os.path.join(path, "config.json"), "w") as f:
         json.dump(config, f, indent=2)
 

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ wheels = [
 
 [[package]]
 name = "promptim"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -766,6 +766,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langsmith" },
     { name = "pandas" },
+    { name = "python-dotenv" },
     { name = "rich" },
 ]
 
@@ -777,6 +778,7 @@ requires-dist = [
     { name = "langchain-openai" },
     { name = "langsmith", specifier = ">=0.1.143" },
     { name = "pandas", specifier = ">=0.2.4" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich" },
 ]
 
@@ -923,6 +925,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview
Added functionality to automatically load environment variables (including LANGSMITH_API_KEY) from a .env file in the current directory when executing promptim commands.

## Background & Purpose
When using promptim with LangSmith for private prompts and dataset management, you need to specify a LANGSMITH_API_KEY. Since many projects store API keys in .env files, it's cumbersome to manually specify the key each time you run a promptim command. This change streamlines the process by automatically loading the key from your project's environment.

## Changes
- Added environment variable loading using python-dotenv when a .env file exists in the current directory
- Added feedback message when environment variables are successfully loaded
- Integrated environment loading at CLI startup

This improvement enhances the developer experience by making it easier to work with private LangSmith resources - simply place your API key in a .env file, and promptim will handle the rest.

Would love to have this merged to make promptim more user-friendly! Let me know if you'd like any adjustments to this implementation.